### PR TITLE
Feature | Color-coded XLSX Spreadsheet Export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "fetters"
 readme = "README.md"
 repository = "https://github.com/JosephLai241/fetters"
-version = "3.0.0"
+version = "3.1.0"
 
 [dependencies]
 chrono = "0.4.41"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ strum = { version = "0.27.2", features = ["derive"] }
 tabled = { version = "0.20.0", features = ["ansi"] }
 thiserror = "2.0.12"
 toml = "0.9.5"
+umya-spreadsheet = "2.3.3"
 
 [dev-dependencies]
 dotenvy = "0.15.7"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,6 +27,8 @@ pub enum Command {
     Config(ConfigOption),
     /// Delete a tracked job application.
     Delete(QueryArgs),
+    /// Export all tracked job applications from a job sprint to a spreadsheet.
+    Export(ExportArgs),
     /// Show job application inslghts.
     Insights,
     /// List job applications.
@@ -41,7 +43,7 @@ pub enum Command {
 }
 
 /// All flags you can use to query jobs.
-#[derive(Debug, Parser)]
+#[derive(Debug, Default, Parser)]
 pub struct QueryArgs {
     #[arg(
         short,
@@ -105,4 +107,29 @@ pub enum SprintOption {
     ShowAll,
     /// Set the current job sprint.
     Set,
+}
+
+/// All subcommands for exporting tracked jobs.
+#[derive(Debug, Parser)]
+pub struct ExportArgs {
+    #[arg(
+        short,
+        long,
+        help = "Export the spreadsheet to the given directory path. Defaults to the current directory if this is not provided."
+    )]
+    pub directory: Option<String>,
+
+    #[arg(
+        short,
+        long,
+        help = "Set a filename for the exported file. The '.xlsx' extension is automatically added if it is not provided. Defaults to '<DATE>-fetters-export-sprint-<SPRINT_NAME>.xlsx'"
+    )]
+    pub filename: Option<String>,
+
+    #[arg(
+        short,
+        long,
+        help = "Select a sprint to export from. Defaults to the current sprint."
+    )]
+    pub sprint: Option<String>,
 }

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -1,0 +1,88 @@
+//! Contains a function called by the CLI when exporting jobs from SQLite.
+
+use std::env;
+
+use chrono::Local;
+use diesel::SqliteConnection;
+use owo_colors::OwoColorize;
+
+use crate::{
+    cli::{ExportArgs, QueryArgs},
+    errors::FettersError,
+    models::sprint::QueriedSprint,
+    repositories::job::JobRepository,
+    utils::spreadsheet::{create_spreadsheet, write_jobs},
+};
+
+/// Export all jobs tracked for a given sprint.
+pub fn export_jobs(
+    connection: &mut SqliteConnection,
+    export_args: &mut ExportArgs,
+    current_sprint: &QueriedSprint,
+) -> Result<(), FettersError> {
+    let target_sprint = if export_args.sprint.is_none() {
+        Some(current_sprint.name.clone())
+    } else {
+        export_args.sprint.clone()
+    };
+
+    let mut job_repo = JobRepository { connection };
+
+    let query_args = QueryArgs {
+        sprint: target_sprint.clone(),
+        ..Default::default()
+    };
+
+    let matched_jobs = job_repo.list_jobs(&query_args, current_sprint)?;
+
+    if matched_jobs.is_empty() {
+        return Err(FettersError::NoJobsAvailable(
+            query_args
+                .sprint
+                .clone()
+                .as_ref()
+                .unwrap_or(&current_sprint.name.clone())
+                .to_string(),
+        ));
+    }
+
+    let (mut spreadsheet, sheet_name) = create_spreadsheet(&target_sprint)?;
+    write_jobs(&mut spreadsheet, &sheet_name, matched_jobs);
+
+    let filename = if let Some(filename) = export_args.filename.clone() {
+        if !filename.ends_with(".xlsx") {
+            format!("{filename}.xlsx")
+        } else {
+            filename
+        }
+    } else {
+        format!(
+            "{}-fetters-export-sprint-{}.xlsx",
+            Local::now().format("%Y-%m-%d"),
+            target_sprint.clone().unwrap_or("unknown".to_string())
+        )
+    };
+
+    let export_path = format!(
+        "{}/{}",
+        export_args
+            .directory
+            .clone()
+            .unwrap_or(env::current_dir()?.to_string_lossy().to_string()),
+        filename,
+    );
+
+    umya_spreadsheet::writer::xlsx::write(&spreadsheet, &export_path)?;
+
+    println!(
+        "{}",
+        format!(
+            "Successfully exported all jobs for sprint {} to path: {export_path}!",
+            target_sprint.unwrap_or("unknown".to_string())
+        )
+        .green()
+        .bold()
+    );
+
+    Ok(())
+}

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -1,6 +1,6 @@
 //! Contains a function called by the CLI when exporting jobs from SQLite.
 
-use std::env;
+use std::{env, path::Path};
 
 use chrono::Local;
 use diesel::SqliteConnection;
@@ -63,22 +63,22 @@ pub fn export_jobs(
         )
     };
 
-    let export_path = format!(
-        "{}/{}",
-        export_args
+    let export_path = Path::new(
+        &export_args
             .directory
             .clone()
             .unwrap_or(env::current_dir()?.to_string_lossy().to_string()),
-        filename,
-    );
+    )
+    .join(Path::new(&filename));
 
     umya_spreadsheet::writer::xlsx::write(&spreadsheet, &export_path)?;
 
     println!(
         "{}",
         format!(
-            "Successfully exported all jobs for sprint {} to path: {export_path}!",
-            target_sprint.unwrap_or("unknown".to_string())
+            "Successfully exported all jobs for sprint {} to path: {}!",
+            target_sprint.unwrap_or("unknown".to_string()),
+            export_path.to_string_lossy()
         )
         .green()
         .bold()

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,6 +3,7 @@
 pub mod add;
 pub mod config;
 pub mod delete;
+pub mod export;
 pub mod insights;
 pub mod list;
 pub mod open;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -31,14 +31,15 @@ pub enum FettersError {
     #[error("No job applications tracked for the current sprint [{0}]")]
     NoJobsAvailable(String),
 
+    /// This error is used when a result returns an error message. This is currently used to
+    /// propagate the error returned when attempting to call `book.set_sheet_name()`.
+    #[error("Set sheet name error: {0}")]
+    SheetNameError(String),
+
     /// This error may be raised if the user attempts to create two new sprints in the same day,
     /// causing a sprint naming conflict (all sprint names should be unique).
     #[error("There is already a sprint with name {0}. Try renaming the sprint.")]
     SprintNameConflict(String),
-
-    /// This error is used when a result returns an error message.
-    #[error("{0}")]
-    StringError(String),
 
     /// Something went wrong when trying to connect to the SQLite database.
     #[error("Failed to connect to SQLite database: {0}")]
@@ -63,6 +64,6 @@ pub enum FettersError {
 
 impl From<&str> for FettersError {
     fn from(value: &str) -> Self {
-        Self::StringError(value.to_string())
+        Self::SheetNameError(value.to_string())
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -36,6 +36,10 @@ pub enum FettersError {
     #[error("There is already a sprint with name {0}. Try renaming the sprint.")]
     SprintNameConflict(String),
 
+    /// This error is used when a result returns an error message.
+    #[error("{0}")]
+    StringError(String),
+
     /// Something went wrong when trying to connect to the SQLite database.
     #[error("Failed to connect to SQLite database: {0}")]
     SQLiteConnectionError(#[from] diesel::ConnectionError),
@@ -51,4 +55,14 @@ pub enum FettersError {
     /// An unknown error occurred.
     #[error("{0}")]
     UnknownError(String),
+
+    /// Something fucked up when exporting job applications to XLSX.
+    #[error("XLSX write error: {0}")]
+    XLSXError(#[from] umya_spreadsheet::XlsxError),
+}
+
+impl From<&str> for FettersError {
+    fn from(value: &str) -> Self {
+        Self::StringError(value.to_string())
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use crate::cli::{Cli, Command, ConfigOption, SprintOption};
 use crate::commands::add::add_job;
 use crate::commands::config::edit_config;
 use crate::commands::delete::delete_job;
+use crate::commands::export::export_jobs;
 use crate::commands::insights::show_insights;
 use crate::commands::list::list_jobs;
 use crate::commands::open::open_application;
@@ -76,6 +77,13 @@ fn main() -> Result<(), FettersError> {
         Command::Delete(mut query_args) => {
             if let Err(error) =
                 delete_job(&mut database.connection, &mut query_args, &current_sprint)
+            {
+                println!("{}", error.red().bold());
+            }
+        }
+        Command::Export(mut export_args) => {
+            if let Err(error) =
+                export_jobs(&mut database.connection, &mut export_args, &current_sprint)
             {
                 println!("{}", error.red().bold());
             }

--- a/src/models/job.rs
+++ b/src/models/job.rs
@@ -128,6 +128,19 @@ impl TabledJob {
 
         field_name.to_string()
     }
+
+    /// Convert the struct to a row of strings to write to a spreadsheet when exporting job
+    /// applications.
+    pub fn convert_to_row(&self) -> Vec<String> {
+        vec![
+            self.created.clone(),
+            self.company_name.clone(),
+            self.title.clone().unwrap_or("N/A".to_string()),
+            self.status.clone().unwrap_or("N/A".to_string()),
+            self.link.clone().unwrap_or("".to_string()),
+            self.notes.clone().unwrap_or("".to_string()),
+        ]
+    }
 }
 
 impl Display for TabledJob {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,4 +3,5 @@
 pub mod display;
 pub mod migrations;
 pub mod prompt;
+pub mod spreadsheet;
 pub mod titles;

--- a/src/utils/spreadsheet.rs
+++ b/src/utils/spreadsheet.rs
@@ -1,0 +1,73 @@
+//! Contains utility functions for exporting job applications to a spreadsheet.
+
+use umya_spreadsheet::{self, Spreadsheet};
+
+use crate::{errors::FettersError, models::job::TabledJob};
+
+/// Create a new spreadsheet for the provided sprint.
+pub fn create_spreadsheet(sprint: &Option<String>) -> Result<(Spreadsheet, String), FettersError> {
+    let sheet_name = format!(
+        "Sprint: {}",
+        sprint.clone().unwrap_or("unknown".to_string())
+    );
+
+    let mut book = umya_spreadsheet::new_file();
+    book.set_sheet_name(0, &sheet_name)?;
+
+    Ok((book, sheet_name))
+}
+
+/// Write exported jobs to the spreadsheet.
+pub fn write_jobs(spreadsheet: &mut Spreadsheet, sheet_name: &str, jobs: Vec<TabledJob>) {
+    let worksheet = spreadsheet.get_sheet_by_name_mut(sheet_name).unwrap();
+
+    let headers = vec![
+        "Timestamp",
+        "Company Name",
+        "Title",
+        "Status",
+        "Link",
+        "Notes",
+    ];
+    for (col, header) in headers.into_iter().enumerate() {
+        let coordinates = ((col + 1) as u32, 1);
+
+        worksheet.get_cell_mut(coordinates).set_value(header);
+
+        let style = worksheet.get_style_mut(coordinates);
+        style.set_background_color("FF999999");
+    }
+
+    for (row_index, job) in jobs.iter().enumerate() {
+        let row_number = (row_index + 2) as u32;
+        let row_values = job.convert_to_row();
+
+        let status_color = if let Some(status) = &job.status {
+            get_status_color(status)
+        } else {
+            "FF999999".to_string()
+        };
+
+        for (column_index, data) in row_values.into_iter().enumerate() {
+            let coordinates = ((column_index + 1) as u32, row_number);
+            worksheet.get_cell_mut(coordinates).set_value(data);
+
+            let style = worksheet.get_style_mut(coordinates);
+            style.set_background_color(&status_color);
+        }
+    }
+}
+
+/// Returns a color based on the job application status.
+fn get_status_color(status: &str) -> String {
+    match status {
+        "GHOSTED" => "FF999999".to_string(),
+        "HIRED" => "FF00A36C".to_string(),
+        "IN PROGRESS" => "FFFFFF00".to_string(),
+        "NOT HIRING ANYMORE" => "FFC9C9C9".to_string(),
+        "OFFER RECEIVED" => "FFFF00FF".to_string(),
+        "PENDING" => "FF0096FF".to_string(),
+        "REJECTED" => "FFEE4B2B".to_string(),
+        _ => "FF999999".to_string(),
+    }
+}


### PR DESCRIPTION
# Description

This PR adds the ability to export all tracked job applications from a job sprint to a spreadsheet through the new `export` subcommand.

This subcommand contains the following additional settings:

- `-d`/`--directory` - Export the spreadsheet to a given directory path (defaults to the current working directory).
- `-f`/`--filename` - Overrides the default filename (defaults to `<DATE>-fetters-export-sprint-<SPRINT_NAME>.xlsx`).
- `-s`/`--sprint` - Export job applications from the specified job sprint (defaults to the current sprint).

The `export` subcommand will create a color-coded XLSX file based on the previously mentioned options.

This should prove useful if/when your state's unemployment office asks you to prove that you've been looking for a job while on unemployment benefits.